### PR TITLE
关于Android8接收不到自定义广播的代码更新

### DIFF
--- a/chapter5/BroadcastTest/app/src/main/java/com/example/broadcasttest/MainActivity.java
+++ b/chapter5/BroadcastTest/app/src/main/java/com/example/broadcasttest/MainActivity.java
@@ -40,6 +40,9 @@ public class MainActivity extends AppCompatActivity {
             @Override
             public void onClick(View v) {
                 Intent intent = new Intent("com.example.broadcasttest.LOCAL_BROADCAST");
+                //如果要在android8上边发送静态广播，需加入Component参数（参数1是自定义广播的包名，参数2是自定义广播的路径）
+                intent.setComponent(new ComponentName("com.example.broadcasttest",
+                        "com.example.broadcasttest.MyBroadcastReceiver"));
                 localBroadcastManager.sendBroadcast(intent); // 发送本地广播
             }
         });


### PR DESCRIPTION
在Android8上接收不到自定义标准广播，因为Android8在静态广播的使用上做了一些限制（具体可查看：https://developer.android.google.cn/about/versions/oreo/android-8.0.html）解决方法是加入Component参数。